### PR TITLE
fix: update deploy workflow for pnpm and Nuxt 3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - '.github/workflows/deploy.yml'
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -25,6 +23,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: 🏗 Setup node env
         uses: actions/setup-node@v4
         with:
@@ -32,9 +33,8 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-
       - name: 👨🏻‍💻 Install dependencies
-        run: pnpm
+        run: pnpm install
 
       - name: 🏗️ Nuxt build
         run: pnpm build


### PR DESCRIPTION
## Summary
Deploy CIが失敗していたため、pnpm と Nuxt 3 に対応するように修正

## Changes
- pnpm インストールステップを追加
- `pnpm` コマンドを `pnpm install` に修正
- デプロイトリガーのパス制限を削除

## Issue
Deploy CIでpnpmが見つからず失敗していた問題を解決

🤖 Generated with [Claude Code](https://claude.ai/code)