### PR TITLE
fix: resolve deploy workflow artifact name mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - '.github/workflows/deploy.yml'
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -22,8 +20,9 @@ jobs:
     steps:
       - name: 🛎 Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: 🏗 Setup node env
         uses: actions/setup-node@v4
@@ -32,9 +31,8 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-
       - name: 👨🏻‍💻 Install dependencies
-        run: pnpm
+        run: pnpm install
 
       - name: 🏗️ Nuxt build
         run: pnpm build
@@ -45,7 +43,6 @@ jobs:
       - name: 🆙 Upload Pages-artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          name: dist
           path: .output/public/
 
   deploy:


### PR DESCRIPTION
## 概要
デプロイワークフローのアーティファクト名の不整合を修正し、GitHub Pagesへのデプロイエラーを解決しました。

## 問題
`upload-pages-artifact@v3`で`name: dist`を指定していましたが、`deploy-pages@v4`はデフォルトで`github-pages`という名前のアーティファクトを探すため、「No artifacts named "github-pages" were found」エラーが発生していました。

## 変更内容
- `upload-pages-artifact`の`name`設定を削除（デフォルトの`github-pages`を使用）
- 欠落していた`pnpm/action-setup@v4`ステップを追加
- 通常のデプロイを阻害していた`paths`フィルターを削除
- インストールコマンドを`pnpm`から`pnpm install`に修正

## テスト内容
- lintチェックが正常に完了
- ワークフローファイルの構文が正しいことを確認

## チェックリスト
- [x] ローカルでlintが通ることを確認
- [x] ワークフロー構文の妥当性を確認
- [x] アーティファクト名の整合性を確保

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>