### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
-onlyBuiltDependencies:
-  - better-sqlite3
+allowBuilds:
+  "@parcel/watcher": true
+  better-sqlite3: true
+  esbuild: true
+  unrs-resolver: true
+  vue-demi: true


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能への対応を行います。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。これにより以下のエラーが発生します:

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる

### 修正

`pnpm-workspace.yaml` の `onlyBuiltDependencies` を `allowBuilds` 形式に移行し、必要なビルドスクリプトを明示的に許可:
- `@parcel/watcher: true`
- `better-sqlite3: true`
- `esbuild: true`
- `unrs-resolver: true`
- `vue-demi: true`

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)